### PR TITLE
SJRK-69: use dynamic grades to construct models when constructing blocks.

### DIFF
--- a/src/js/storyTelling-ui-storyEditor.js
+++ b/src/js/storyTelling-ui-storyEditor.js
@@ -149,10 +149,15 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                                             }
                                         }
                                     },
-                                    // TODO: this won't work because it's not a model bind
                                     block: {
                                         options: {
-                                            model: "{blockUi}.options.additionalConfiguration.modelValues"
+                                            gradeNames: ["{that}.getBlockGrade"],
+                                            invokers: {
+                                                "getBlockGrade": {
+                                                    funcName: "sjrk.storyTelling.ui.getBlockGradeFromEventModelValues",
+                                                    args: ["{blockUi}.options.additionalConfiguration.modelValues"]
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/src/js/storyTelling-ui-storyViewer.js
+++ b/src/js/storyTelling-ui-storyViewer.js
@@ -81,7 +81,13 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                                     },
                                     block: {
                                         options: {
-                                            model: "{blockUi}.options.additionalConfiguration.modelValues"
+                                            gradeNames: ["{that}.getBlockGrade"],
+                                            invokers: {
+                                                "getBlockGrade": {
+                                                    funcName: "sjrk.storyTelling.ui.getBlockGradeFromEventModelValues",
+                                                    args: ["{blockUi}.options.additionalConfiguration.modelValues"]
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/src/js/storyTelling-ui.js
+++ b/src/js/storyTelling-ui.js
@@ -83,6 +83,23 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
         completionEvent.fire();
     };
 
+    /* Fabricates a grade based on the model values passed in from the event
+    /* This roundabout approach is necessary to ensure that we can have
+    /* model values from the event merged successfully with the base values
+    /* of the block
+    /* TODO: is there a better approach than this, perhaps something using
+    /* a mergePolicy?
+    */
+    sjrk.storyTelling.ui.getBlockGradeFromEventModelValues = function (modelValuesFromEvent) {
+        var gradeName = "sjrk.storyTelling.ui.storyEditor.block-" + fluid.allocateGuid();
+        fluid.defaults(gradeName, {
+            // TODO: this should test that modelValuesFromEvent is a legitimate
+            // model object, rather than simply existing
+            model: modelValuesFromEvent  ? modelValuesFromEvent : {}
+        });
+        return gradeName;
+    };
+
     // TODO: add tests for this function in the appropriate place(s)
     /* Given a collection of story block data, will fire a creation event for each,
      * specifying a grade name based on a lookup list. The format of the lookup list is:
@@ -96,6 +113,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
      * - "createEvent": the event that is to be fired in order to create the blocks
      */
     sjrk.storyTelling.ui.createBlocksFromData = function (storyBlocks, blockTypeLookup, createEvent) {
+        console.log("sjrk.storyTelling.ui.createBlocksFromData");
         fluid.each(storyBlocks, function (blockData) {
             var gradeNames = blockTypeLookup[blockData.blockType];
             createEvent.fire(gradeNames, {modelValues: blockData});


### PR DESCRIPTION
Use dynamic grades to construct models when constructing blocks. from events, in order to make sure any model values supplied by events are smoothly merged with models from base grades.

This is a solve for the issues we were seeing with persisting blocks between language switches.