### PR TITLE
SJRK-49: make menu Browse link configurable.

### DIFF
--- a/src/js/storyTelling-ui-menu.js
+++ b/src/js/storyTelling-ui-menu.js
@@ -35,9 +35,23 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 "args": ["es", "{that}.events.onInterfaceLanguageChangeRequested.fire"]
             }
         },
+        // Allows the browse link to be reconfigured
+        menuConfig: {
+            templateValues: {
+                "menu_browseLinkUrl": "/src/html/storyBrowse.html"
+            }
+        },
         components: {
             templateManager: {
                 options: {
+                    listeners: {
+                        "onAllResourcesLoaded.renderTemplateOnSelf": {
+                            funcName: "{that}.renderTemplateOnSelf",
+                            // Passes in menuConfig.templateValues to
+                            // the dynamicValues argument
+                            args: ["{menu}.options.menuConfig.templateValues"]
+                        }
+                    },
                     templateConfig: {
                         templatePath: "%resourcePrefix/src/templates/menu.handlebars"
                     }

--- a/src/templates/menu.handlebars
+++ b/src/templates/menu.handlebars
@@ -1,5 +1,5 @@
 <div lang="{{localizedMessages.language}}" class="sjrk-storyTelling-menu-browse-link-container">
-    <a href="/src/html/storyBrowse.html" class="sjrk-storyTelling-menu-browse-link">{{localizedMessages.message_menu_browseLinkText}}</a>
+    <a href="{{dynamicValues.menu_browseLinkUrl}}" class="sjrk-storyTelling-menu-browse-link">{{localizedMessages.message_menu_browseLinkText}}</a>
 </div>
 <div lang="{{localizedMessages.language}}" class="sjrk-storyTelling-menu-languages-container">
     <a href="javascript:void(0)" class="sjrk-storyTelling-menu-languages-en sjrkc-storyTelling-menu-languages-en">{{localizedMessages.message_menu_english}}</a> |


### PR DESCRIPTION
Addresses the issue of the "Browse Stories" link being hard-coded in the template - it is now configurable from the menu component. 