### PR TITLE
SJRK-104: Add inverse transform for not transformation.

### DIFF
--- a/src/ui/transforms.js
+++ b/src/ui/transforms.js
@@ -113,11 +113,17 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
      * - "input": the value to negate
      */
     fluid.defaults("sjrk.storyTelling.transforms.not", {
-        gradeNames: ["fluid.standardTransformFunction"]
+        gradeNames: ["fluid.standardTransformFunction"],
+        invertConfiguration: "sjrk.storyTelling.transforms.not.invert"
     });
 
     sjrk.storyTelling.transforms.not = function (input) {
         return !input;
+    };
+
+    sjrk.storyTelling.transforms.not.invert = function (transformSpec) {
+        transformSpec.type = "sjrk.storyTelling.transforms.not";
+        return transformSpec;
     };
 
 })(jQuery, fluid);

--- a/tests/ui/js/transformsTests.js
+++ b/tests/ui/js/transformsTests.js
@@ -401,18 +401,23 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
     };
 
     jqUnit.test("Test negate transform function", function () {
-        jqUnit.expect(23);
+        jqUnit.expect(46);
 
         fluid.each(negateTransformTestCases, function (testCase, index) {
-            var transformSpec = { type: "sjrk.storyTelling.transforms.not", inputPath: "input" };
+            var transformRules = {
+                value: {
+                    transform: {
+                        type: "sjrk.storyTelling.transforms.not", inputPath: "input"
+                    }
+                }
+            };
 
-            var transformRules = { transform: transformSpec };
+            var result = fluid.model.transformWithRules(testCase, transformRules);
+            jqUnit.assertEquals("Transformation of test case " + index + " is as expected", testCase.expectedResult, result.value);
 
-            var resultString = fluid.model.transformWithRules(
-                { input: testCase.input },
-                { resultString: transformRules }
-            ).resultString;
-            jqUnit.assertEquals("Negative of test case " + index + " is as expected", testCase.expectedResult, resultString);
+            var inverseRules = fluid.model.transform.invertConfiguration(transformRules);
+            var inverseResult = fluid.model.transformWithRules({value: testCase.expectedResult}, inverseRules);
+            jqUnit.assertEquals("Inverse transformation of test case " + index + " is as expected", testCase.expectedInverseResult, inverseResult.input);
         });
     });
 


### PR DESCRIPTION
You'll probably want to massage either the style of the "Test negate transform function" tests or your previous tests so they are consistent. Also, you may want to provide some helper functions for the duplicate configuration setups that may happen across all of them.